### PR TITLE
Including woff2 font file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,7 @@
   "main":[
     "fonts/fontawesome-webfont.eot",
     "fonts/fontawesome-webfont.woff",
+    "fonts/fontawesome-webfont.woff2",
     "fonts/fontawesome-webfont.ttf",
     "fonts/fontawesome-webfont.svg",
     "less/font-awesome.less"


### PR DESCRIPTION
Missing the woff2 file in the bower.json.
